### PR TITLE
FISH-6556 Succeed TriggerControllerFuture.cancel When Inner Future is Done

### DIFF
--- a/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedScheduledThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedScheduledThreadPoolExecutor.java
@@ -645,7 +645,9 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             // cancel the next scheduled task if there is one
             ManagedTriggerSingleFutureTask<V> future = getCurrentFuture();
             if (future != null) {
-                return future.cancel(mayInterruptIfRunning);
+                boolean alreadyDone = future.isDone();
+                //  return true if the currentFuture is "Completed normally"
+                return future.cancel(mayInterruptIfRunning) || alreadyDone;
             }
             return true;
         }


### PR DESCRIPTION
The inner future (currentFuture) is used for repeating execution and its state is set to NORMAL/[Completed normally] after each cycle. The TriggerControllerFuture.cancel should return true even if this inner future is done.