### PR TITLE
Update OSGi Version

### DIFF
--- a/osgi.bundle
+++ b/osgi.bundle
@@ -17,4 +17,4 @@
 -exportcontents: \
                         org.glassfish.enterprise.concurrent; \
                         org.glassfish.enterprise.concurrent.internal; \
-                        org.glassfish.enterprise.concurrent.spi; version=2.0
+                        org.glassfish.enterprise.concurrent.spi; version=3.1


### PR DESCRIPTION
forgotten OSGi version upgrade

I'm not sure if it is required (2.0 was there for the whole 3.0 version), but it seems to me that we should correct it.