### PR TITLE
Publish getAdapter to AbstractManagedExecutorService

### DIFF
--- a/src/main/java/org/glassfish/enterprise/concurrent/AbstractManagedExecutorService.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/AbstractManagedExecutorService.java
@@ -85,6 +85,8 @@ extends AbstractExecutorService implements ManagedExecutorService {
 
     public abstract ManagedThreadFactoryImpl getManagedThreadFactory();
 
+    public abstract ManagedExecutorService getAdapter();
+
     protected abstract ExecutorService getThreadPoolExecutor();
 
     protected <T> T doInvokeAny(Collection<? extends Callable<T>> tasks, boolean timed, long nanos) throws InterruptedException, ExecutionException, TimeoutException {

--- a/src/main/java/org/glassfish/enterprise/concurrent/ForkJoinManagedExecutorService.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/ForkJoinManagedExecutorService.java
@@ -101,6 +101,7 @@ public class ForkJoinManagedExecutorService extends AbstractPlatformThreadExecut
      * disabled for use by application components.
      *
      */
+    @Override
     public ManagedExecutorServiceAdapter getAdapter() {
         return adapter;
     }

--- a/src/main/java/org/glassfish/enterprise/concurrent/ManagedExecutorServiceImpl.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/ManagedExecutorServiceImpl.java
@@ -124,6 +124,7 @@ public class ManagedExecutorServiceImpl extends AbstractPlatformThreadExecutorSe
      * @return The ManagedExecutorService instance with life cycle operations
      *         disabled for use by application components.
      **/
+    @Override
     public ManagedExecutorServiceAdapter getAdapter() {
         return adapter;
     }

--- a/src/main/java/org/glassfish/enterprise/concurrent/ManagedScheduledExecutorServiceImpl.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/ManagedScheduledExecutorServiceImpl.java
@@ -120,6 +120,7 @@ public class ManagedScheduledExecutorServiceImpl extends AbstractPlatformThreadE
      * @return The ManagedScheduledExecutorService instance with life cycle
      *         operations disabled for use by application components.
      */
+    @Override
     public ManagedScheduledExecutorServiceAdapter getAdapter() {
         return adapter  ;
     }


### PR DESCRIPTION
This is used by all MESes, so it makes sense to be be accessible at this level.