### PR TITLE
Throw exception in managed task so that it has to be handled or logged.

### DIFF
--- a/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedFutureTask.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/internal/ManagedFutureTask.java
@@ -245,13 +245,14 @@ public class ManagedFutureTask<V> extends FutureTask<V> implements Future<V> {
     private void abort() {
         // Context handle not in valid state, throws AbortedException and
         // do not run the task
-        AbortedException ex = new AbortedException(contextSetupException.getMessage());
+        AbortedException ex = new AbortedException(contextSetupException.getMessage(), contextSetupException);
         setException(ex);
         if (taskListener != null) {
             // notify listener. No need to set context here as it wouldn't work
             // anyway
             taskListener.taskAborted(this, executor.getExecutorForTaskListener(), task, ex);
         }
+        throw new RuntimeException(ex);
     }
 
 }


### PR DESCRIPTION
To avoid that the exception is swallowed in case there's no ManagedTask listener. 
Also add the original exception as the cause to add it to the stacktrace. 