### PR TITLE
Update dependencies to the latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,10 +90,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <maven.compiler.release>17</maven.compiler.release>
-        <jakarta.enterprise.concurrent-api.version>3.1.0-M1</jakarta.enterprise.concurrent-api.version>
-        <jakarta.interceptor-api.version>2.2.0-M1</jakarta.interceptor-api.version>    
+        <jakarta.enterprise.concurrent-api.version>3.1.0-M2</jakarta.enterprise.concurrent-api.version>
+        <jakarta.interceptor-api.version>2.2.0</jakarta.interceptor-api.version>    
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>    
-        <jakarta.enterprise.cdi-api.version>4.1.0-M1</jakarta.enterprise.cdi-api.version>
+        <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
           
         <java21.sourceDirectory>${project.basedir}/src/main/java21</java21.sourceDirectory>
         <java21.testSourceDirectory>${project.basedir}/src/test/java21</java21.testSourceDirectory>


### PR DESCRIPTION
Specifically interceptor is updated to the final one, which now doesn't drag in the wrong annotations version anymore.