### PR TITLE
Add Virtual Threads Package to OSGi Exports

### DIFF
--- a/osgi.bundle
+++ b/osgi.bundle
@@ -17,4 +17,5 @@
 -exportcontents: \
                         org.glassfish.enterprise.concurrent; \
                         org.glassfish.enterprise.concurrent.internal; \
-                        org.glassfish.enterprise.concurrent.spi; version=3.1
+                        org.glassfish.enterprise.concurrent.spi; \
+                        org.glassfish.enterprise.concurrent.virtualthreads; version=3.1


### PR DESCRIPTION
Without this package, OSGi complains about missing package.