### PR TITLE
Use Javatime in Managed Scheduled Thread Pool Executor

### DIFF
--- a/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
@@ -527,7 +527,7 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
         extends ManagedScheduledFutureTask<V> {
 
         private TriggerControllerFuture controller;
-        private final long scheduledRunTime;
+        private final ZonedDateTime scheduledRunTime;
         
         ManagedTriggerSingleFutureTask(AbstractManagedExecutorService executor, 
                                  Callable<V> callable,
@@ -536,7 +536,7 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
                                  TriggerControllerFuture controller) {
             super(executor, callable, ns);
             this.controller = controller;
-            this.scheduledRunTime = scheduledRunTime;
+            this.scheduledRunTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(scheduledRunTime), ZoneId.systemDefault());
         }
 
         ManagedTriggerSingleFutureTask(AbstractManagedExecutorService executor, 
@@ -546,7 +546,7 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
                                  TriggerControllerFuture controller) {
             super(executor, r, null, ns);
             this.controller = controller;
-            this.scheduledRunTime = scheduledRunTime;
+            this.scheduledRunTime = ZonedDateTime.ofInstant(Instant.ofEpochMilli(scheduledRunTime), ZoneId.systemDefault());
         }
         
         private long getDelayFromDate(Date nextRunTime) {
@@ -560,17 +560,17 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
 
         @Override
         public void run() {
-            if (controller.skipRun(new Date(scheduledRunTime))) {
+            if (controller.skipRun(Date.from(scheduledRunTime.toInstant()))) {
                 return;
             }
-            long lastRunStartTime = System.currentTimeMillis();
+            ZonedDateTime lastRunStartTime = ZonedDateTime.now();
             Object lastResult = null;
             try {
                 super.run();
                 lastResult = get();
             } catch (Throwable t) {             
             }
-            long lastRunEndTime = System.currentTimeMillis();
+            ZonedDateTime lastRunEndTime = ZonedDateTime.now();
             controller.doneExecution(lastResult, 
                     scheduledRunTime, lastRunStartTime, lastRunEndTime);
         }
@@ -680,7 +680,7 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             return skip;
         }
 
-        void doneExecution(V result, long scheduledStart, long runStart, long runEnd) {
+        void doneExecution(V result, ZonedDateTime scheduledStart, ZonedDateTime runStart, ZonedDateTime runEnd) {
             lastExecution = new LastExecutionImpl(result, scheduledStart,
                     runStart, runEnd);
             // schedule next run
@@ -719,12 +719,20 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             private V result;
             private ZonedDateTime scheduledStart, runStart, runEnd;
 
-            public LastExecutionImpl(V result, long scheduledStart,
-                    long runStart, long runEnd) {
+//            public LastExecutionImpl(V result, long scheduledStart,
+//                    long runStart, long runEnd) {
+//                this.result = result;
+//                this.scheduledStart = scheduledStart == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(scheduledStart), ZoneId.systemDefault());
+//                this.runStart = runStart == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(runStart), ZoneId.systemDefault());
+//                this.runEnd = runEnd == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(runEnd), ZoneId.systemDefault());
+//            }
+
+            public LastExecutionImpl(V result, ZonedDateTime scheduledStart,
+                    ZonedDateTime runStart, ZonedDateTime runEnd) {
                 this.result = result;
-                this.scheduledStart = scheduledStart == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(scheduledStart), ZoneId.systemDefault());
-                this.runStart = runStart == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(runStart), ZoneId.systemDefault());
-                this.runEnd = runEnd == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(runEnd), ZoneId.systemDefault());
+                this.scheduledStart = scheduledStart;
+                this.runStart = runStart;
+                this.runEnd = runEnd;
             }
 
             @Override

--- a/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
@@ -719,14 +719,6 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             private V result;
             private ZonedDateTime scheduledStart, runStart, runEnd;
 
-//            public LastExecutionImpl(V result, long scheduledStart,
-//                    long runStart, long runEnd) {
-//                this.result = result;
-//                this.scheduledStart = scheduledStart == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(scheduledStart), ZoneId.systemDefault());
-//                this.runStart = runStart == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(runStart), ZoneId.systemDefault());
-//                this.runEnd = runEnd == 0L ? null : ZonedDateTime.ofInstant(Instant.ofEpochMilli(runEnd), ZoneId.systemDefault());
-//            }
-
             public LastExecutionImpl(V result, ZonedDateTime scheduledStart,
                     ZonedDateTime runStart, ZonedDateTime runEnd) {
                 this.result = result;


### PR DESCRIPTION
Previous implementation used number of milliseconds for scheduling. The problem was during scheduling every second, sometimes the process was too fast, under 1 millisecond. The last time lost the nanoseconds part, e.g. `ZonedDateTime` planned the next execution to the exact same time. Keeping nanoseconds forces planning to the next second.

Example of executions with schedule `"* * * * * *"`:
```
  Cron Trigger running, #4 at 19:30:22.302340267
  Cron Trigger running, #5 at 19:30:23.000287937
  Cron Trigger running, #6 at 19:30:23.303162670
  Cron Trigger running, #7 at 19:30:24.000863731
```

The value `19:30:23.000287937` was converted to milliseconds, e.g. time `19:30:23` and the next schedule was `19:30:23` This is the behavior of [CronTrigger](https://github.com/jakartaee/concurrency/blob/dad8f6f3f99146ca7bf0f3f613e2f6c7e6dc9c4d/api/src/main/java/jakarta/enterprise/concurrent/CronTrigger.java#L439), see its test: [2023, 4, 22, 12 -> 2023, 4, 22, 12](https://github.com/jakartaee/concurrency/blob/dad8f6f3f99146ca7bf0f3f613e2f6c7e6dc9c4d/api/src/test/java/jakarta/enterprise/concurrent/CronTriggerTest.java#L365).

This change uses `ZonedDateTime` instead of `long`, so it doesn't loose the nanoseconds and the next schedule after `19:30:23.000287937` is `19:30:24`.