### PR TITLE
Check If Skipped in Scheduled Executor Before the First Execution

### DIFF
--- a/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
@@ -605,6 +605,7 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             this.callable = callable;
             this.taskScheduledTime = new Date(System.currentTimeMillis());
             scheduleNextRun();
+            skipped = trigger.skipRun(lastExecution, taskScheduledTime);
             submitted();
         }
 
@@ -614,6 +615,7 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
             this.callable = Executors.callable(runnable);
             this.taskScheduledTime = new Date(System.currentTimeMillis());
             scheduleNextRun();
+            skipped = trigger.skipRun(lastExecution, taskScheduledTime);
             submitted();
         }
 


### PR DESCRIPTION
TriggerTests.triggerSkipRunTest check, if the first run was skipped. The current implementation didn't cover this scenario. This change enforces this check in constructor.