### PR TITLE
Delete redundant log message "afterBeanDiscovery" in ConcurrentCDIExtension

### DIFF
--- a/src/main/java/org/glassfish/concurro/cdi/ConcurrentCDIExtension.java
+++ b/src/main/java/org/glassfish/concurro/cdi/ConcurrentCDIExtension.java
@@ -190,8 +190,8 @@ public class ConcurrentCDIExtension implements Extension {
      * @param event
      */
     void afterBeanDiscovery(@Observes final AfterBeanDiscovery event, BeanManager beanManager) {
+        log.finest("ConcurrentCDIExtension.afterBeanDiscovery");
         try {
-            log.severe("afterBeanDiscovery");
             // define default beans, if there is no user-defined factory
             if (!isCSProduced) {
                 event.addBean()


### PR DESCRIPTION
Fixes #88.

Deletes a SEVERE message in `ConcurrentCDIExtension#afterBeanDiscovery(AfterBeanDiscovery, BeanManager)` that was likely inserted for debugging purpose.