### PR TITLE
Avoid NPE if task is set to null concurrently

### DIFF
--- a/src/main/java/org/glassfish/enterprise/concurrent/ManagedThreadFactoryImpl.java
+++ b/src/main/java/org/glassfish/enterprise/concurrent/ManagedThreadFactoryImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2022 Payara Foundation and/or its affiliates.
  *
@@ -334,6 +335,7 @@ public class ManagedThreadFactoryImpl implements ManagedThreadFactory {
 
         @Override
         boolean cancelTask() {
+            var task = this.task;
             if (task != null) {
                 return task.cancel(true);
             }
@@ -342,6 +344,7 @@ public class ManagedThreadFactoryImpl implements ManagedThreadFactory {
 
         @Override
         public String getTaskIdentityName() {
+            var task = this.task;
             if (task != null) {
                 return task.getTaskIdentityName();
             }


### PR DESCRIPTION
- #99 but for 3.0.x
- #47