### PR TITLE
Fix multi-release build and speed up test execution and organize imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
                             </goals>
                             <configuration>
                                 <release>21</release>
+                                <multiReleaseOutput>true</multiReleaseOutput>
                                 <compileSourceRoots>
                                     <compileSourceRoot>${java21.sourceDirectory}</compileSourceRoot>
                                 </compileSourceRoots>

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
           
         <java21.sourceDirectory>${project.basedir}/src/main/java21</java21.sourceDirectory>
         <java21.testSourceDirectory>${project.basedir}/src/test/java21</java21.testSourceDirectory>
+
+        <!-- speed up test execution - run all tests in parallel -->
+        <parallel>classesAndMethods</parallel>
+        <useUnlimitedThreads>true</useUnlimitedThreads>
+
     </properties>
 
     <dependencies>

--- a/src/main/java/org/glassfish/concurro/virtualthreads/VirtualThreadsManagedExecutorService.java
+++ b/src/main/java/org/glassfish/concurro/virtualthreads/VirtualThreadsManagedExecutorService.java
@@ -16,14 +16,19 @@
 package org.glassfish.concurro.virtualthreads;
 
 import jakarta.enterprise.concurrent.ManagedExecutorService;
-import org.glassfish.concurro.*;
+
 import java.util.concurrent.ExecutorService;
+
 import jakarta.enterprise.concurrent.ManagedTaskListener;
 
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 
+import org.glassfish.concurro.AbstractManagedExecutorService;
+import org.glassfish.concurro.AbstractManagedExecutorService.RejectPolicy;
+import org.glassfish.concurro.ContextServiceImpl;
+import org.glassfish.concurro.ManagedThreadFactoryImpl;
 import org.glassfish.concurro.internal.ManagedFutureTask;
 
 /**


### PR DESCRIPTION
Fixes https://github.com/eclipse-ee4j/glassfish-concurro/issues/121

Java 21 classes were built to the same location as Java 17 classes, and overwrote them.  The end result was that there are no multirelease classes and the virtual threads classes have Java 21 bytecode version, incompatible with Java 17 (as seen in the 3.1.0-M5 version)

I also set the tests to execute in parallel. A lot of them just schedule new threads and then wait for a couple of seconds, running them sequentially is just too slow for no purpose. It's safe to run them in parallel.