### PR TITLE
[master] 182 Test and Fix

### DIFF
--- a/src/main/java/org/glassfish/concurro/internal/ManagedFutureTask.java
+++ b/src/main/java/org/glassfish/concurro/internal/ManagedFutureTask.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import org.glassfish.concurro.AbstractManagedExecutorService;
+import org.glassfish.concurro.AbstractManagedThread;
 import org.glassfish.concurro.spi.ContextHandle;
 import org.glassfish.concurro.spi.ContextSetupProvider;
 
@@ -114,6 +115,15 @@ public class ManagedFutureTask<V> extends FutureTask<V> implements Future<V> {
         }
     }
 
+    /**
+     * See @{@link ManagedThreadPoolExecutor#beforeExecute(Thread, Runnable)}
+     * @param t
+     */
+    protected void beforeExecute(Thread t) {
+        setupContext();
+        starting(t);
+    }
+
     @Override
     public void run() {
         if (contextSetupException == null) {
@@ -132,6 +142,19 @@ public class ManagedFutureTask<V> extends FutureTask<V> implements Future<V> {
         }
 
         return false;
+    }
+
+    /**
+     * See @{@link ManagedThreadPoolExecutor#afterExecute(Runnable, Throwable)}
+     * @param t
+     */
+    protected void afterExecute(Throwable t) {
+        try {
+            done(t);
+        }
+        finally {
+            resetContext();
+        }
     }
 
     @Override

--- a/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/concurro/internal/ManagedScheduledThreadPoolExecutor.java
@@ -321,34 +321,24 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
 
    @Override
     protected void afterExecute(Runnable r, Throwable t) {
-        super.afterExecute(r, t);
-
-        ManagedScheduledThreadPoolExecutor.ManagedScheduledFutureTask task = (ManagedScheduledThreadPoolExecutor.ManagedScheduledFutureTask) r;
-        try {
-            task.done(t /*task.getTaskRunException()*/);
-        }
-        finally {
-            task.resetContext();
-            // Kill thread if thread older than threadLifeTime
-            if (threadLifeTime > 0) {
-                Thread thread = Thread.currentThread();
-                if (thread instanceof AbstractManagedThread) {
-                    long threadStartTime = ((AbstractManagedThread)thread).getThreadStartTime();
-                    if ((System.currentTimeMillis() - threadStartTime)/1000 > threadLifeTime) {
-                        throw new ThreadExpiredException();
-                    }
-                }
-            }
-        }
+       super.afterExecute(r, t);
+       ((ManagedScheduledThreadPoolExecutor.ManagedScheduledFutureTask) r).afterExecute(t);
+       // Kill thread if thread older than threadLifeTime
+       if (threadLifeTime > 0) {
+           Thread thread = Thread.currentThread();
+           if (thread instanceof AbstractManagedThread) {
+               long threadStartTime = ((AbstractManagedThread)thread).getThreadStartTime();
+               if ((System.currentTimeMillis() - threadStartTime)/1000 > threadLifeTime) {
+                   throw new ThreadExpiredException();
+               }
+           }
+       }
     }
 
     @Override
     protected void beforeExecute(Thread t, Runnable r) {
+        ((ManagedScheduledThreadPoolExecutor.ManagedScheduledFutureTask) r).beforeExecute(t);
         super.beforeExecute(t, r);
-
-        ManagedFutureTask task = (ManagedFutureTask) r;
-        task.setupContext();
-        task.starting(t);
     }
 
     public <V> ManagedFutureTask<V> newTaskFor(
@@ -402,6 +392,11 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
          * Index into delay queue, to support faster cancellation.
          */
         int heapIndex;
+
+        /**
+         * flag that run() uses to indicate the task should be reExecuted
+         */
+        boolean reExecute = false;
 
         /**
          * Creates a one-shot action with given nanoTime-based execution time.
@@ -520,6 +515,15 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
         }
 
         /**
+         * See @{@link ManagedScheduledThreadPoolExecutor#beforeExecute(Thread, Runnable)}
+         * @param t
+         */
+        protected void beforeExecute(Thread t) {
+            setupContext();
+            starting(t);
+        }
+
+        /**
          * Overrides FutureTask version so as to reset/requeue if periodic.
          */
         @Override
@@ -532,8 +536,28 @@ public class ManagedScheduledThreadPoolExecutor extends ScheduledThreadPoolExecu
                 ManagedScheduledThreadPoolExecutor.ManagedScheduledFutureTask.super.run();
             }
             else if (ManagedScheduledThreadPoolExecutor.ManagedScheduledFutureTask.super.runAndReset()) {
-                    setNextRunTime();
+                setNextRunTime();
+                reExecute = true;
+            }
+        }
+
+        /**
+         * See @{@link ManagedScheduledThreadPoolExecutor#afterExecute(Runnable, Throwable)}
+         * @param t
+         */
+        protected void afterExecute(Throwable t) {
+            try {
+                try {
+                    done(t /*task.getTaskRunException()*/);
+                }
+                finally {
+                    resetContext();
+                }
+            } finally {
+                if (reExecute) {
+                    reExecute = false;
                     reExecutePeriodic(outerTask);
+                }
             }
         }
     }

--- a/src/main/java/org/glassfish/concurro/internal/ManagedThreadPoolExecutor.java
+++ b/src/main/java/org/glassfish/concurro/internal/ManagedThreadPoolExecutor.java
@@ -63,21 +63,14 @@ public class ManagedThreadPoolExecutor extends ThreadPoolExecutor {
     @Override
     protected void afterExecute(Runnable r, Throwable t) {
         super.afterExecute(r, t);
-
-        ManagedFutureTask task = (ManagedFutureTask) r;
-        try {
-            task.done(t);
-        }
-        finally {
-            task.resetContext();
-            // Kill thread if thread older than threadLifeTime
-            if (threadLifeTime > 0) {
-                Thread thread = Thread.currentThread();
-                if (thread instanceof AbstractManagedThread) {
-                    long threadStartTime = ((AbstractManagedThread)thread).getThreadStartTime();
-                    if ((System.currentTimeMillis() - threadStartTime)/1000 > threadLifeTime) {
-                        throw new ThreadExpiredException();
-                    }
+        ((ManagedFutureTask) r).afterExecute(t);
+        // Kill thread if thread older than threadLifeTime
+        if (threadLifeTime > 0) {
+            Thread thread = Thread.currentThread();
+            if (thread instanceof AbstractManagedThread) {
+                long threadStartTime = ((AbstractManagedThread)thread).getThreadStartTime();
+                if ((System.currentTimeMillis() - threadStartTime)/1000 > threadLifeTime) {
+                    throw new ThreadExpiredException();
                 }
             }
         }
@@ -85,11 +78,8 @@ public class ManagedThreadPoolExecutor extends ThreadPoolExecutor {
 
     @Override
     protected void beforeExecute(Thread t, Runnable r) {
+        ((ManagedFutureTask) r).beforeExecute(t);
         super.beforeExecute(t, r);
-
-        ManagedFutureTask task = (ManagedFutureTask) r;
-        task.setupContext();
-        task.starting(t);
     }
 
 }

--- a/src/test/java/org/glassfish/concurro/ManagedScheduledExecutorServiceAdapterTest.java
+++ b/src/test/java/org/glassfish/concurro/ManagedScheduledExecutorServiceAdapterTest.java
@@ -34,9 +34,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.glassfish.concurro.AbstractManagedExecutorService.RejectPolicy;
 import org.glassfish.concurro.spi.ContextSetupProvider;
@@ -323,6 +326,70 @@ public class ManagedScheduledExecutorServiceAdapterTest extends ManagedExecutorS
 
         taskListener.verifyCallback(ManagedTestTaskListener.SUBMITTED, future, instance, task, null);
         taskListener.verifyCallback(ManagedTestTaskListener.STARTING, future, instance, task, null, classloaderName);
+    }
+
+    /**
+     * Tests that replicates issue https://github.com/eclipse-ee4j/glassfish-concurro/issues/182
+     * @throws Throwable
+     */
+    @Test
+    public void testScheduleAtFixedRate_182() throws Throwable {
+        final String classloaderName = "testScheduleAtFixedRate_ConcurrentContextReset" + LocalDateTime.now();
+        // we need an executor with 2 threads to replicate the issue
+        final ManagedScheduledExecutorService instance = new ManagedScheduledExecutorServiceImpl(classloaderName, null, 0, false,
+                2,
+                0, TimeUnit.SECONDS,
+                0L,
+                new TestContextService(new ClassloaderContextSetupProvider(classloaderName)),
+                RejectPolicy.ABORT)
+                .getAdapter();
+        final int numberOfTasks = 5;
+        final long taskPeriod = 500;
+        final Thread testThread = Thread.currentThread();
+        final AtomicBoolean firstTask = new AtomicBoolean(true);
+        final AtomicReference<Throwable> testException = new AtomicReference<>();
+        final AtomicBoolean testRunning = new AtomicBoolean(false);
+        final ManagedTestTaskListener managedTaskListener = new ManagedTestTaskListener() {
+            @Override
+            public void taskDone(Future<?> future, ManagedExecutorService executor, Object task, Throwable exception) {
+                super.taskDone(future, executor, task, exception);
+                if (exception != null) {
+                    if (testRunning.get()) {
+                        testException.set(exception);
+                        testThread.interrupt();
+                    }
+                } else {
+                    if (testRunning.get() && firstTask.compareAndSet(true, false)) {
+                        // hold the first task long enough so the second task runs in a diff thread and complete its run and triggers the issue in case it still exists
+                        try {
+                            Thread.sleep(3*taskPeriod);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            }
+        };
+        final ScheduledFuture<?> future = instance.scheduleAtFixedRate(new ManagedRunnableTestTask(managedTaskListener), 0L, taskPeriod, TimeUnit.MILLISECONDS);
+        try {
+            testRunning.set(true);
+            try {
+                Thread.sleep(taskPeriod * numberOfTasks);
+            } catch (InterruptedException e) {
+                if (testException.get() == null) {
+                    // unexpected interrupt, rethrow
+                    throw e;
+                }
+            } finally {
+                // signals the listener that test is done
+                testRunning.set(false);
+            }
+            if (testException.get() != null) {
+                fail(testException.get());
+            }
+        } finally {
+            future.cancel(true);
+        }
     }
 
     @Test

--- a/src/test/java/org/glassfish/concurro/test/ClassloaderContextSetupProvider.java
+++ b/src/test/java/org/glassfish/concurro/test/ClassloaderContextSetupProvider.java
@@ -40,7 +40,7 @@ public class ClassloaderContextSetupProvider implements ContextSetupProvider {
 
     @Override
     public ContextHandle saveContext(ContextService contextService) {
-        return new SavedContext(Thread.currentThread().getContextClassLoader());
+        return new SavedContext(Thread.currentThread());
     }
 
     @Override
@@ -54,29 +54,38 @@ public class ClassloaderContextSetupProvider implements ContextSetupProvider {
         ClassLoader contextClassLoader =
                 new NamedClassLoader(classloaderName, savedContext.originalClassloader);
         Thread.currentThread().setContextClassLoader(contextClassLoader);
-        return new SavedContext(classloaderBeforeSetup);
+        return new SavedContext(classloaderBeforeSetup, Thread.currentThread().getId());
     }
 
     @Override
     public void reset(ContextHandle contextHandle) {
         numResetCalled++;
         SavedContext savedContext = (SavedContext)contextHandle;
-        Thread.currentThread().setContextClassLoader(savedContext.originalClassloader);
+        final Thread currentThread = Thread.currentThread();
+        if (currentThread.getId() != savedContext.threadId) {
+            throw new IllegalStateException();
+        }
+        currentThread.setContextClassLoader(savedContext.originalClassloader);
     }
 
     @Override
     public ContextHandle saveContext(ContextService contextService, Map<String, String> contextObjectProperties) {
         contextServiceProperties = contextObjectProperties;
-        return new SavedContext(Thread.currentThread().getContextClassLoader());
+        return new SavedContext(Thread.currentThread());
     }
 
     static class SavedContext implements ContextHandle {
         transient ClassLoader originalClassloader;
+        transient long threadId;
 
-        public SavedContext(ClassLoader originalClassloader) {
-            this.originalClassloader = originalClassloader;
+        public SavedContext(Thread thread) {
+            this(thread.getContextClassLoader(), thread.getId());
         }
 
+        public SavedContext(ClassLoader originalClassloader, long threadId) {
+            this.originalClassloader = originalClassloader;
+            this.threadId = threadId;
+        }
     }
 
 }


### PR DESCRIPTION
Issue: https://github.com/eclipse-ee4j/glassfish-concurro/issues/182
Branch: master


Please note that I went beyond the fix, and introduced a design for both thread pool executors, to delegate beforeExecution and afterExecution to related future tasks, IMHO it makes logic easier to understand and follow.